### PR TITLE
Fix 'epmty' typo

### DIFF
--- a/1D-MUSIC.ipynb
+++ b/1D-MUSIC.ipynb
@@ -363,7 +363,7 @@
     "The values we'll see are arbitrary, i.e. as they exist in the memory address allocated for our array.  \n",
     "'''\n",
     "print('np.empty: ')\n",
-    "arrayviz(epmty)"
+    "arrayviz(empty)"
    ]
   },
   {


### PR DESCRIPTION
Typo when showing how empty numpy arrays work